### PR TITLE
Add Firefox/Gecko build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 test_course_codes.txt
 course_chunk.txt
 main_page_response.txt
+dist-firefox/
+web-ext-artifacts/

--- a/FIREFOX.md
+++ b/FIREFOX.md
@@ -1,0 +1,59 @@
+# Firefox / Gecko build
+
+PESU-MAX also builds for Firefox and other Gecko browsers (Zen, LibreWolf, Waterfox).
+Same features as the Chrome build, from the same sources.
+
+## Build
+
+```bash
+npm install
+```
+
+```bash
+npm run build:firefox
+```
+
+Output lands in `dist-firefox/`. The Chrome build is unchanged and still produced by
+`npm run build:chrome` (output: `dist/`); `npm run build` defaults to Chrome.
+
+| Script | What it does |
+| --- | --- |
+| `npm run build:firefox` | Production Firefox build → `dist-firefox/` |
+| `npm run dev:firefox` | Firefox build in watch mode |
+| `npm run lint:firefox` | `web-ext lint` against the built extension |
+| `npm run package:firefox` | Zips `dist-firefox/` into `web-ext-artifacts/` |
+
+## Installing
+
+**For testing:** open `about:debugging#/runtime/this-firefox` → *Load Temporary Add-on…* →
+pick `dist-firefox/manifest.json`. Firefox drops temporary add-ons on restart.
+
+**Permanently:** Firefox and its derivatives enforce add-on signing on release builds, so a
+permanent install needs a Mozilla-signed XPI. Signing on the **unlisted** channel is free and
+automated and does not publish the add-on publicly:
+
+```bash
+npx web-ext sign --source-dir dist-firefox --channel unlisted --artifacts-dir web-ext-artifacts --api-key YOUR_JWT_ISSUER --api-secret YOUR_JWT_SECRET
+```
+
+API credentials come from https://addons.mozilla.org/en-US/developers/addon/api/key/.
+
+## What differs from the Chrome build
+
+| Area | Chrome | Firefox |
+| --- | --- | --- |
+| Background | `background.service_worker` | `background.scripts` — Firefox MV3 uses event pages and ignores `service_worker` |
+| Add-on identity | n/a | `browser_specific_settings.gecko.id` + `strict_min_version`, required for signing and stable updates |
+| File downloads | base64 `data:` URL | Blob URL — `downloads.download()` rejects `data:` URLs on Firefox with "Access denied for URL" |
+| Babel target | `chrome: 88` | `firefox: 128` |
+
+Download plumbing is consolidated in `src/helpers/browserDownload.js`, which picks the right
+strategy per target from the webpack-injected `__TARGET_BROWSER__` flag and revokes each blob
+URL once its download reaches a terminal state. The three call sites (bulk course-material
+zip, single PYQ, PYQ zip) all route through it.
+
+The `chrome.*` namespace is left as-is throughout: Firefox aliases it to `browser.*` and
+supports the callback style this codebase uses, so no polyfill is needed.
+
+Host permissions are granted at install time on Firefox 127+, but remain revocable from
+`about:addons` → PESU-MAX → Permissions.

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,0 +1,45 @@
+{
+  "manifest_version": 3,
+  "name": "PESU-MAX",
+  "version": "2.0.2",
+  "description": "Bulk-download course material, attendance/GPA calculators, faculty info and PYQs for PESU Academy.",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "pesu-max@dhyan.local",
+      "strict_min_version": "128.0"
+    }
+  },
+  "action": {
+    "default_popup": "src/popup/index.html"
+  },
+  "background": {
+    "scripts": ["background/background.js"]
+  },
+  "permissions": ["cookies", "storage", "downloads", "alarms"],
+  "host_permissions": [
+    "https://www.pesuacademy.com/*",
+    "https://files.pesuacademy.com/*",
+    "https://staff.pes.edu/*",
+    "http://library.pes.edu/*",
+    "https://library.pes.edu/*",
+    "https://www.ilovepdf.com/*",
+    "https://*.ilovepdf.com/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["https://www.pesuacademy.com/*"],
+      "js": ["content/content.js"]
+    }
+  ],
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["icons/Pes_logo_square_ui.png"],
+      "matches": ["https://www.pesuacademy.com/*"]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
-  "name": "my-extension",
+  "name": "pesu-max-firefox",
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "webpack --mode development --watch",
-    "build": "webpack --mode production",
-    "build:dev": "webpack --mode development"
+    "build": "webpack --mode production --env browser=firefox",
+    "build:firefox": "webpack --mode production --env browser=firefox",
+    "build:firefox:dev": "webpack --mode development --env browser=firefox",
+    "build:chrome": "webpack --mode production --env browser=chrome",
+    "dev": "webpack --mode development --watch --env browser=firefox",
+    "lint": "web-ext lint --source-dir dist-firefox",
+    "package": "web-ext build --source-dir dist-firefox --artifacts-dir web-ext-artifacts --overwrite-dest",
+    "sign": "web-ext sign --source-dir dist-firefox --channel unlisted --artifacts-dir web-ext-artifacts"
   },
-  "description": "",
+  "description": "Firefox (Gecko) port of PESU-MAX",
   "main": "index.js",
   "keywords": [],
   "author": "",
@@ -37,6 +42,7 @@
     "style-loader": "^3.3.4",
     "terser-webpack-plugin": "^5.3.14",
     "webpack": "^5.103.0",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.1.4",
+    "web-ext": "^8.3.0"
   }
 }

--- a/src/helpers/browserDownload.js
+++ b/src/helpers/browserDownload.js
@@ -1,0 +1,89 @@
+/**
+ * Single entry point for handing a generated file to the browser's downloader.
+ *
+ * The two engines need opposite things here:
+ *   - Chrome MV3 runs the background as a service worker, which has no DOM and
+ *     therefore no URL.createObjectURL, so a base64 `data:` URL is the only way out.
+ *   - Firefox MV3 runs the background as an event page (DOM available), and its
+ *     downloads.download() flatly rejects `data:` URLs with "Access denied for URL".
+ *     Blob URLs are the supported path, and they avoid buffering the whole file
+ *     as a base64 string, which matters for big course-material zips.
+ *
+ * __TARGET_BROWSER__ is injected by webpack (see webpack.config.cjs).
+ */
+
+const IS_FIREFOX = __TARGET_BROWSER__ === "firefox";
+
+function arrayBufferToBase64(arrayBuffer) {
+  let binary = "";
+  const bytes = new Uint8Array(arrayBuffer);
+  const chunkSize = 0x8000;
+
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    const chunk = bytes.subarray(index, index + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+
+  return btoa(binary);
+}
+
+// Blob URLs stay alive until revoked; hold each one until its download settles.
+function revokeWhenSettled(downloadId, objectUrl) {
+  const listener = (delta) => {
+    if (delta.id !== downloadId) return;
+    const state = delta.state?.current;
+    if (state === "complete" || state === "interrupted") {
+      chrome.downloads.onChanged.removeListener(listener);
+      URL.revokeObjectURL(objectUrl);
+    }
+  };
+
+  chrome.downloads.onChanged.addListener(listener);
+
+  // Safety net in case the download never reports a terminal state.
+  setTimeout(() => {
+    chrome.downloads.onChanged.removeListener(listener);
+    URL.revokeObjectURL(objectUrl);
+  }, 10 * 60 * 1000);
+}
+
+/**
+ * @param {Blob} blob
+ * @param {string} filename  Relative to the browser's download directory.
+ * @param {{ saveAs?: boolean }} [options]
+ * @returns {Promise<number>} the download id
+ */
+export async function downloadBlob(blob, filename, options = {}) {
+  const { saveAs = false } = options;
+
+  let url;
+  let objectUrl = null;
+
+  if (IS_FIREFOX) {
+    objectUrl = URL.createObjectURL(blob);
+    url = objectUrl;
+  } else {
+    const base64 = arrayBufferToBase64(await blob.arrayBuffer());
+    url = `data:${blob.type || "application/octet-stream"};base64,${base64}`;
+  }
+
+  return new Promise((resolve, reject) => {
+    chrome.downloads.download({ url, filename, saveAs }, (downloadId) => {
+      if (chrome.runtime.lastError) {
+        if (objectUrl) URL.revokeObjectURL(objectUrl);
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+
+      if (objectUrl) revokeWhenSettled(downloadId, objectUrl);
+      resolve(downloadId);
+    });
+  });
+}
+
+/**
+ * Convenience wrapper for callers that already hold an ArrayBuffer.
+ */
+export function downloadBuffer(arrayBuffer, mimeType, filename, options = {}) {
+  return downloadBlob(new Blob([arrayBuffer], { type: mimeType }), filename, options);
+}

--- a/src/helpers/downloadController.js
+++ b/src/helpers/downloadController.js
@@ -1,4 +1,5 @@
 import { createBulkDownloadZip } from './downloadHelper.js';
+import { downloadBlob } from './browserDownload.js';
 import { CONTENT_TYPE_IDS } from './pesuAPI.js';
 
 const DEFAULT_CONTENT_TYPES = [CONTENT_TYPE_IDS.slides];
@@ -33,53 +34,46 @@ export async function handleBulkDownload(selectedItems, contentTypes, mergeOptio
     }
   };
 
-  try {
-    const result = await createBulkDownloadZip(selectedItems, progressCallback, typesToDownload, {
-      mergeOptions,
-      mergeSlides
-    });
-    
-    // Convert blob to data URL 
-    const arrayBuffer = await result.blob.arrayBuffer();
-    const base64 = btoa(
-      new Uint8Array(arrayBuffer)
-        .reduce((data, byte) => data + String.fromCharCode(byte), '')
-    );
-    const dataUrl = `data:application/zip;base64,${base64}`;
-    
-    chrome.downloads.download({
-      url: dataUrl,
-      filename: `PESU_Materials_${Date.now()}.zip`,
-      saveAs: true
-    }, (downloadId) => {
-      if (chrome.runtime.lastError) {
-        console.error("Download error:", chrome.runtime.lastError);
-        sendResponse({ 
-          error: chrome.runtime.lastError.message,
-          stats: result.stats 
-        });
-      } else {
-        sendResponse({
-          success: true,
-          downloadId: downloadId,
-          stats: result.stats
-        });
-      }
-      
-      if (port) {
-        try {
-          port.disconnect();
-        } catch (e) {}
-      }
-    });
-  } catch (error) {
-    console.error("Bulk download error:", error);
-    sendResponse({ error: error.message });
-    
+  const closePort = () => {
     if (port) {
       try {
         port.disconnect();
       } catch (e) {}
     }
+  };
+
+  let result;
+  try {
+    result = await createBulkDownloadZip(selectedItems, progressCallback, typesToDownload, {
+      mergeOptions,
+      mergeSlides
+    });
+  } catch (error) {
+    console.error("Bulk download error:", error);
+    sendResponse({ error: error.message });
+    closePort();
+    return;
+  }
+
+  try {
+    const downloadId = await downloadBlob(
+      result.blob,
+      `PESU_Materials_${Date.now()}.zip`,
+      { saveAs: true }
+    );
+
+    sendResponse({
+      success: true,
+      downloadId: downloadId,
+      stats: result.stats
+    });
+  } catch (error) {
+    console.error("Download error:", error);
+    sendResponse({
+      error: error.message,
+      stats: result.stats
+    });
+  } finally {
+    closePort();
   }
 }

--- a/src/services/libraryPyq.js
+++ b/src/services/libraryPyq.js
@@ -1,6 +1,7 @@
 import JSZip from "jszip";
 import * as cheerio from "cheerio";
 import { load, save } from "../utils/storage.js";
+import { downloadBlob } from "../helpers/browserDownload.js";
 
 const LIBRARY_BASE_URL = "http://library.pes.edu";
 const LOGIN_URL = `${LIBRARY_BASE_URL}/MyPage.aspx`;
@@ -471,19 +472,6 @@ function buildPaginatedSearchResponse({ query, parsed, fields, pageIndex, loaded
   };
 }
 
-function arrayBufferToBase64(arrayBuffer) {
-  let binary = "";
-  const bytes = new Uint8Array(arrayBuffer);
-  const chunkSize = 0x8000;
-
-  for (let index = 0; index < bytes.length; index += chunkSize) {
-    const chunk = bytes.subarray(index, index + chunkSize);
-    binary += String.fromCharCode(...chunk);
-  }
-
-  return btoa(binary);
-}
-
 function ensurePdfExtension(name) {
   return name.toLowerCase().endsWith(".pdf") ? name : `${name}.pdf`;
 }
@@ -491,26 +479,6 @@ function ensurePdfExtension(name) {
 function buildZipFileName(query) {
   const safeQuery = sanitizeFilename(query || "PYQs") || "PYQs";
   return `PESU_PYQs_${safeQuery}.zip`;
-}
-
-function triggerBrowserDownload(url, filename) {
-  return new Promise((resolve, reject) => {
-    chrome.downloads.download(
-      {
-        url,
-        filename,
-        saveAs: false
-      },
-      (downloadId) => {
-        if (chrome.runtime.lastError) {
-          reject(new Error(chrome.runtime.lastError.message));
-          return;
-        }
-
-        resolve(downloadId);
-      }
-    );
-  });
 }
 
 export async function getPyqCourseCatalog() {
@@ -713,17 +681,14 @@ export async function downloadLibraryPyq({
     throw new Error(`Unable to download file (HTTP ${fileResponse.status})`);
   }
 
-  const fileBlob = await fileResponse.blob();
-  const fileBuffer = await fileBlob.arrayBuffer();
-  const fileBase64 = arrayBufferToBase64(fileBuffer);
   const mimeType = (fileResponse.headers.get("Content-Type") || "application/pdf").split(";")[0];
-  const dataUrl = `data:${mimeType};base64,${fileBase64}`;
+  const fileBlob = new Blob([await fileResponse.arrayBuffer()], { type: mimeType });
 
   const fallbackName = `PYQ_${Date.now()}`;
   const safeName = sanitizeFilename(title || fallbackName) || fallbackName;
   const hasPdfExtension = safeName.toLowerCase().endsWith(".pdf");
   const fileName = hasPdfExtension ? safeName : `${safeName}.pdf`;
-  const downloadId = await triggerBrowserDownload(dataUrl, `PESU_PYQs/${fileName}`);
+  const downloadId = await downloadBlob(fileBlob, `PESU_PYQs/${fileName}`);
 
   return {
     downloadId,
@@ -795,11 +760,8 @@ export async function downloadLibraryPyqsZip({
     compression: "DEFLATE",
     compressionOptions: { level: 4 }
   });
-  const zipBuffer = await zipBlob.arrayBuffer();
-  const zipBase64 = arrayBufferToBase64(zipBuffer);
-  const zipDataUrl = `data:application/zip;base64,${zipBase64}`;
   const fileName = buildZipFileName(query);
-  const downloadId = await triggerBrowserDownload(zipDataUrl, `PESU_PYQs/${fileName}`);
+  const downloadId = await downloadBlob(zipBlob, `PESU_PYQs/${fileName}`);
 
   return {
     downloadId,

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,13 +1,36 @@
 const path = require('path');
+const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
-module.exports = (env, argv) => {
+// Firefox is the default target for this fork; `--env browser=chrome` still
+// produces the upstream Chrome MV3 build from the same sources.
+const TARGETS = {
+  firefox: {
+    outputDir: 'dist-firefox',
+    manifest: 'manifest.firefox.json',
+    babelTargets: { firefox: '128' }
+  },
+  chrome: {
+    outputDir: 'dist',
+    manifest: 'manifest.json',
+    babelTargets: { chrome: '88' }
+  }
+};
+
+module.exports = (env = {}, argv = {}) => {
   const isProduction = argv.mode === 'production';
+  const browser = env.browser || 'firefox';
+  const target = TARGETS[browser];
+
+  if (!target) {
+    throw new Error(`Unknown browser target "${browser}". Use firefox or chrome.`);
+  }
 
   return {
     mode: isProduction ? 'production' : 'development',
+    // Never an eval-based devtool: extension page CSP forbids eval in both engines.
     devtool: isProduction ? 'source-map' : 'cheap-module-source-map',
 
     entry: {
@@ -18,7 +41,7 @@ module.exports = (env, argv) => {
     },
 
     output: {
-      path: path.resolve(__dirname, 'dist'),
+      path: path.resolve(__dirname, target.outputDir),
       filename: '[name]/[name].js',
       clean: true,
       publicPath: '/'
@@ -34,7 +57,7 @@ module.exports = (env, argv) => {
           extractComments: false,
         }),
       ],
-      // CRITICAL: Disable ALL code splitting for Chrome Extension MV3
+      // CRITICAL: MV3 background scripts cannot load extra chunks at runtime.
       splitChunks: false,
       runtimeChunk: false,
     },
@@ -49,7 +72,7 @@ module.exports = (env, argv) => {
             options: {
               presets: [
                 ['@babel/preset-env', {
-                  targets: { chrome: '88' },
+                  targets: target.babelTargets,
                   modules: false
                 }],
                 ['@babel/preset-react', {
@@ -82,6 +105,9 @@ module.exports = (env, argv) => {
     },
 
     plugins: [
+      new webpack.DefinePlugin({
+        __TARGET_BROWSER__: JSON.stringify(browser)
+      }),
       new HtmlWebpackPlugin({
         template: './src/popup/index.html',
         filename: 'src/popup/index.html',
@@ -99,7 +125,7 @@ module.exports = (env, argv) => {
       new CopyPlugin({
         patterns: [
           {
-            from: 'manifest.json',
+            from: target.manifest,
             to: 'manifest.json'
           },
           {


### PR DESCRIPTION
Firefox cannot run the Chrome MV3 build. Three things block it:

- Firefox MV3 uses background event pages and ignores background.service_worker, so the extension installs but never starts.
- downloads.download() rejects data: URLs on Firefox (Access denied for URL), which breaks every download - the bulk course-material zip and both PYQ paths. Firefox's background is a page with DOM access, so blob URLs work there; Chrome MV3 has no DOM in the service worker and needs the data: URL. Both strategies now live in src/helpers/browserDownload.js, selected by a webpack-injected __TARGET_BROWSER__ flag, with blob URLs revoked once the download settles.
- Signing and stable updates need browser_specific_settings.gecko.id.

manifest.firefox.json holds the Gecko manifest; webpack takes --env browser=firefox|chrome and emits to dist-firefox/ or dist/. The Chrome build is unaffected: same entry points, same manifest.json, same output directory.

chrome.* is left alone throughout - Firefox aliases it and supports the callback style already used here, so no polyfill is needed.

Verified on Zen 1.21.14b (Gecko 153): web-ext lint reports 0 errors, and a bulk download of a full semester produces a correct merged PDF.

Im just a student at PES, I do not know how to develop extensions, I used AI to assist me to figure out what was not working and used it to write the fix as well, I did testing by hand on my own account before opening these PRs.