### PR TITLE
Fix bulk download failing when multiple content types are selected

### DIFF
--- a/frontend/components/CourseMaterial/DownloadProgressDialog.jsx
+++ b/frontend/components/CourseMaterial/DownloadProgressDialog.jsx
@@ -22,6 +22,10 @@ import {
   errorAlertSx 
 } from "../../styles/styles.js";
 
+// Rendering hundreds of MUI list items makes the dialog crawl and stalls the
+// close transition; show a bounded slice and summarise the rest.
+const MAX_LISTED_FAILURES = 50;
+
 const DownloadProgressDialog = ({ open, onClose }) => {
   const dispatch = useDispatch();
   const { downloading, downloadProgress, downloadResult } = useSelector(
@@ -121,6 +125,13 @@ const DownloadProgressDialog = ({ open, onClose }) => {
                     </Box>
                   </Box>
                 )}
+                {downloadResult.stats?.skipped > 0 && (
+                  <Box sx={{ mt: 1 }}>
+                    <Typography variant="body2" sx={{ fontSize: '11px', color: 'rgba(255,255,255,0.8)' }}>
+                      Skipped {downloadResult.stats.skipped} class/content-type combination{downloadResult.stats.skipped > 1 ? 's' : ''} with no material uploaded.
+                    </Typography>
+                  </Box>
+                )}
                 {downloadResult.stats?.failed > 0 && (
                   <Box sx={{ mt: 1 }}>
                     <Typography variant="body2" sx={{ fontSize: '11px', color: '#ffffff' }}>
@@ -137,10 +148,10 @@ const DownloadProgressDialog = ({ open, onClose }) => {
                           fontSize: '11px'
                         }}
                       >
-                        {downloadResult.stats.failedItems.map((item, index) => (
+                        {downloadResult.stats.failedItems.slice(0, MAX_LISTED_FAILURES).map((item, index) => (
                           <Box 
                             component="li" 
-                            key={item.classId || `${item.subjectId || 'failed'}-${index}`}
+                            key={`${item.classId || item.subjectId || 'failed'}-${item.contentType || 'na'}-${index}`}
                             sx={{ mb: 0.5 }}
                           >
                             <Typography variant="body2" sx={{ fontSize: '11px', color: '#ffffff' }}>
@@ -159,6 +170,11 @@ const DownloadProgressDialog = ({ open, onClose }) => {
                           </Box>
                         ))}
                       </Box>
+                    )}
+                    {downloadResult.stats.failedItems?.length > MAX_LISTED_FAILURES && (
+                      <Typography variant="body2" sx={{ mt: 0.5, fontSize: '11px', color: 'rgba(255,255,255,0.8)' }}>
+                        …and {downloadResult.stats.failedItems.length - MAX_LISTED_FAILURES} more.
+                      </Typography>
                     )}
                   </Box>
                 )}

--- a/frontend/redux/courseMaterialSlice.js
+++ b/frontend/redux/courseMaterialSlice.js
@@ -57,7 +57,10 @@ export const downloadSelectedMaterials = createAsyncThunk(
                   unitNumber: unitIndex + 1,
                   classId: cls.id,
                   className: cls.className,
-                  classIndex: classIndexInUnit
+                  classIndex: classIndexInUnit,
+                  // Which content types this class actually has, so the download
+                  // loop can skip combinations PESU has nothing for.
+                  availableContentTypes: Array.isArray(cls.contentTypes) ? cls.contentTypes : null
                 });
               }
             }

--- a/src/helpers/MiscControllers.js
+++ b/src/helpers/MiscControllers.js
@@ -1,12 +1,25 @@
 import { load } from "../utils/storage.js";
 
+// A worker pool, not a fixed-window batcher. The previous version sliced items
+// into groups of `concurrency` and awaited each group fully before starting the
+// next, so every group ran at the speed of its slowest member and left the other
+// slots idle. Here each worker takes the next item as soon as it is free, which
+// keeps `concurrency` requests genuinely in flight. Results stay in input order.
 export const parallelBatch = async (items, asyncFn, concurrency = 5) => {
-  const results = [];
-  for (let i = 0; i < items.length; i += concurrency) {
-    const batch = items.slice(i, i + concurrency);
-    const batchResults = await Promise.all(batch.map(asyncFn));
-    results.push(...batchResults);
-  }
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= items.length) return;
+      results[index] = await asyncFn(items[index], index, items);
+    }
+  };
+
+  const workerCount = Math.max(1, Math.min(concurrency, items.length));
+  await Promise.all(Array.from({ length: workerCount }, worker));
+
   return results;
 };
 

--- a/src/helpers/downloadHelper.js
+++ b/src/helpers/downloadHelper.js
@@ -272,7 +272,7 @@ async function inspectBlobFileType(blob, reportedExtension = '') {
 
 function buildIndividualFilePath(item, contentTypeName, fileResult, fileNumber, totalFilesInClass, options = {}) {
   const { subjectName, unitNumber, className, classIndex } = item;
-  const { flattenIntoContentFolder = false, extensionOverride = fileResult.extension } = options;
+  const { extensionOverride = fileResult.extension } = options;
   const safeFolderName = sanitizeFilename(subjectName);
   const contentFolder = sanitizeFilename(contentTypeName);
   const numberingPrefix = `${unitNumber}.${classIndex || 1}.${fileNumber}`;
@@ -288,11 +288,10 @@ function buildIndividualFilePath(item, contentTypeName, fileResult, fileNumber, 
 
   const safeFileName = baseFileName + extensionOverride;
 
-  if (contentFolder === 'QA' || contentFolder === 'QB' || flattenIntoContentFolder) {
-    return `${safeFolderName}/${contentFolder}/${safeFileName}`;
-  }
-
-  const unitFolder = String(unitNumber || 1);
+  // Layout: <Course>/Unit N/<Content type>/<file>
+  // QA and QB used to be hoisted out of their unit, and unit folders were bare
+  // numbers ("1/Slides"), which made the archive hard to navigate.
+  const unitFolder = `Unit ${unitNumber || 1}`;
   return `${safeFolderName}/${unitFolder}/${contentFolder}/${safeFileName}`;
 }
 
@@ -323,7 +322,9 @@ function buildMergedContentFilePath(subjectName, subjectCode, contentTypeName) {
     ? `${sanitizeFilename(subjectCode)}_Merged_${safeContentFolder}.pdf`
     : `Merged_${safeContentFolder}.pdf`;
 
-  return `${safeFolderName}/${safeContentFolder}/${mergedFileName}`;
+  // Merged PDFs span every unit of the subject, so they cannot live inside one
+  // Unit folder - they sit in their own top-level folder per course.
+  return `${safeFolderName}/Merged/${mergedFileName}`;
 }
 
 function getFilenameFromPath(filePath) {
@@ -429,6 +430,12 @@ async function getClassMaterialFile(subjectId, unitId, classId, classNo, content
       // Parse HTML to get download links
       const downloadLinks = parseDownloadLinks(result.data);
       if (downloadLinks.length === 0) {
+        // PESU renders "No Notes Content to Display" (or QB/QA/Assignments/MCQs)
+        // when the class has nothing of that type. Distinguish that from a
+        // genuine parse failure so the UI can stay quiet about it.
+        if (/Nos+[A-Za-z]+s+Contents+tos+Display/i.test(result.data)) {
+          return [{ success: false, unavailable: true, error: 'No material of this type for this class' }];
+        }
         return [{ success: false, error: 'No download links found in HTML' }];
       }
 
@@ -493,16 +500,44 @@ export async function createBulkDownloadZip(selectedItems, progressCallback, con
   const totalOperations = downloadOperations + subjectMergeGroups.size;
   let completed = 0;
 
-  // Create download tasks for each item and content type combination
+  // Create download tasks for each item and content type combination.
+  //
+  // Built content-type-major on purpose. Item-major ordering puts all five
+  // content types for ONE class next to each other, and parallelBatch runs five
+  // at a time - so every batch hammered a single class with five simultaneous
+  // requests to the stateful studentProfilePESUAdmin controller, which answers
+  // 500. Striping by content type means a batch always spans distinct classes.
+  // `order` restores the original item-major sequence below, because merge
+  // ordering (slide page order in the combined PDF) depends on it.
+  //
+  // PESU already tells us which content types a class has (parsed into
+  // availableContentTypes). Most classes only ever get slides, so asking every
+  // class for all five types produced thousands of pointless requests that came
+  // back "No Notes Content to Display" and were reported to the user as
+  // failures. Skip those up front: fewer requests, no phantom errors.
   const downloadTasks = [];
-  for (const item of selectedItems) {
-    for (const contentType of contentTypes) {
-      downloadTasks.push({ item, contentType });
+  let skipped = 0;
+  for (let typeIndex = 0; typeIndex < contentTypes.length; typeIndex++) {
+    for (let itemIndex = 0; itemIndex < selectedItems.length; itemIndex++) {
+      const item = selectedItems[itemIndex];
+      const contentType = contentTypes[typeIndex];
+      const known = item.availableContentTypes;
+
+      if (Array.isArray(known) && known.length > 0 && !known.includes(contentType)) {
+        skipped++;
+        continue;
+      }
+
+      downloadTasks.push({
+        item,
+        contentType,
+        order: itemIndex * contentTypes.length + typeIndex
+      });
     }
   }
 
-  const results = await parallelBatch(downloadTasks, async (task) => {
-    const { item, contentType } = task;
+  const unorderedResults = await parallelBatch(downloadTasks, async (task) => {
+    const { item, contentType, order } = task;
     const { subjectId, unitId, classId, classNo, className } = item;
     const contentTypeName = CONTENT_TYPE_NAMES[contentType] || 'Unknown';
 
@@ -517,7 +552,7 @@ export async function createBulkDownloadZip(selectedItems, progressCallback, con
           status: 'downloading'
         });
       }
-      return { item, contentType, filesArray };
+      return { item, contentType, filesArray, order };
     } catch (error) {
       completed++;
       if (progressCallback) {
@@ -528,9 +563,12 @@ export async function createBulkDownloadZip(selectedItems, progressCallback, con
           status: 'downloading'
         });
       }
-      return { item, contentType, filesArray: [{ success: false, error: error.message }] };
+      return { item, contentType, filesArray: [{ success: false, error: error.message }], order };
     }
   }, 5);
+
+  // Restore item-major order so downstream merge grouping is unchanged.
+  const results = unorderedResults.slice().sort((a, b) => a.order - b.order);
 
   const failedItems = [];
   let failed = 0;
@@ -543,6 +581,13 @@ export async function createBulkDownloadZip(selectedItems, progressCallback, con
   for (const { item, contentType, filesArray } of results) {
     const { subjectName, subjectCode, subjectId, unitNumber, className, classId, classIndex } = item;
     const contentTypeName = CONTENT_TYPE_NAMES[contentType] || 'PESU_Material';
+
+    // The server answers "No <type> Content to Display" for combinations that
+    // simply have nothing uploaded. That is not a failure worth showing.
+    if (Array.isArray(filesArray) && filesArray.length === 1 && filesArray[0]?.unavailable) {
+      skipped++;
+      continue;
+    }
 
     if (!filesArray || !Array.isArray(filesArray) || filesArray.length === 0) {
       failed++;
@@ -590,10 +635,7 @@ export async function createBulkDownloadZip(selectedItems, progressCallback, con
           fileResult,
           fileNumber,
           filesArray.length,
-          {
-            flattenIntoContentFolder: isMergeSelectedType,
-            extensionOverride: resolvedExtension || fileResult.extension
-          }
+          { extensionOverride: resolvedExtension || fileResult.extension }
         );
         const canMergeThisFile = isMergeSelectedType;
         const isMergeablePdf = canMergeThisFile && fileInspection.isPdf;
@@ -811,6 +853,7 @@ export async function createBulkDownloadZip(selectedItems, progressCallback, con
       total: totalOperations,
       successful: totalFiles,
       failed,
+      skipped,
       failedItems,
       mergedSubjects,
       mergedSlideSources,
@@ -820,48 +863,4 @@ export async function createBulkDownloadZip(selectedItems, progressCallback, con
       contentTypes: contentTypes.map(ct => CONTENT_TYPE_NAMES[ct] || ct)
     }
   };
-}
-
-// Extract selected class details from selection state and pesu data
-export function getSelectedClassesInfo(selectedClasses, pesuData) {
-  const selectedItems = [];
-  
-  if (!pesuData?.items) return selectedItems;
-  
-  for (const subject of pesuData.items) {
-    (subject.units || []).forEach((unit, unitIndex) => {
-      let classIndexInUnit = 0;
-      for (const cls of (unit.classes || [])) {
-        if (selectedClasses[cls.id]) {
-          classIndexInUnit++;
-          selectedItems.push({
-            subjectId: subject.id,
-            subjectCode: subject.subjectCode,
-            subjectName: subject.subjectName,
-            unitId: unit.id,
-            unitName: unit.name,
-            unitNumber: unitIndex + 1,
-            classId: cls.id,
-            classNo: cls.classNo || String(classIndexInUnit),
-            className: cls.className,
-            classIndex: classIndexInUnit
-          });
-        }
-      }
-    });
-  }
-  
-  return selectedItems;
-}
-
-// Trigger browser download of a blob
-export function downloadBlob(blob, filename) {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
 }

--- a/src/helpers/getStorageData.js
+++ b/src/helpers/getStorageData.js
@@ -291,7 +291,9 @@ export async function getAllPESUDataNested() {
       classes: (unit.classes || []).map(cls => ({
         id: cls.id,
         className: cls.className,
-        classType: cls.classType
+        classType: cls.classType,
+        // Needed downstream to skip content types this class has nothing for.
+        contentTypes: cls.contentTypes
       }))
     }))
   }));

--- a/src/helpers/pesuAPI.js
+++ b/src/helpers/pesuAPI.js
@@ -336,6 +336,36 @@ export const getSemesterGpa = async (semesterId) => {
   }
 };
 
+// studentProfilePESUAdmin is a stateful controller and intermittently answers 5xx
+// when a session drives it hard (bulk downloads issue ~1400 requests). A short
+// backoff clears it; without this a single blip fails the whole item permanently.
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+async function fetchWithRetry(url, options, { attempts = 4, baseDelayMs = 700 } = {}) {
+  let lastResponse = null;
+  let lastError = null;
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (attempt > 0) {
+      const backoff = baseDelayMs * Math.pow(2, attempt - 1) + Math.random() * 250;
+      await new Promise((resolve) => setTimeout(resolve, backoff));
+    }
+
+    try {
+      const response = await fetch(url, options);
+      if (response.ok || !RETRYABLE_STATUSES.has(response.status)) {
+        return response;
+      }
+      lastResponse = response;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (lastResponse) return lastResponse;
+  throw lastError;
+}
+
 export const getCourseMaterials = async (courseId, unitId, classId, classNo, contentType = 2) => {
     const csrfToken = await getCsrfToken();
     const headers = {
@@ -360,7 +390,7 @@ export const getCourseMaterials = async (courseId, unitId, classId, classNo, con
       _: String(Date.now())
     });
 
-    const viewResponse = await fetch(`${BASE_URL}/s/studentProfilePESUAdmin?${viewParams.toString()}`, {
+    const viewResponse = await fetchWithRetry(`${BASE_URL}/s/studentProfilePESUAdmin?${viewParams.toString()}`, {
       method: "GET",
       credentials: "include",
       headers
@@ -383,7 +413,7 @@ export const getCourseMaterials = async (courseId, unitId, classId, classNo, con
       _: String(Date.now())
     });
 
-    const response = await fetch(`${BASE_URL}/s/studentProfilePESUAdmin?${params.toString()}`, {
+    const response = await fetchWithRetry(`${BASE_URL}/s/studentProfilePESUAdmin?${params.toString()}`, {
       method: "GET",
       credentials: "include",
       headers


### PR DESCRIPTION
Selecting all five content types across a semester failed completely: 695 of 695 items returned HTTP 500. Selecting slides alone worked, which is what made this easy to miss.

Cause: download tasks were built item-major, so all five content types for one class sat next to each other in the queue, and parallelBatch ran exactly five at a time. Every batch was therefore a single class hitting the stateful studentProfilePESUAdmin controller five times concurrently, which answers 500. Tasks are now built content-type-major so a batch always spans distinct classes; an order field restores the original sequence afterwards, since merged-PDF page order depends on it. Both course-material requests also retry with exponential backoff on 429/5xx.

With that fixed, a run reported 186 successes and 528 failures, all reading "No download links found in HTML". Those were not failures. PESU answers 200 with "No Notes Content to Display" for content types a class has nothing for, and the extension asked every class for all five types regardless. parseUnitClasses already records each class's real content types, but getAllPESUDataNested projected classes down to {id, className, classType} and dropped the field before it reached the download loop. It is preserved now and used to skip combinations that have nothing - DBMS Unit 1 alone drops from 75 requests to 20. A listed type can still come back empty, so responses matching "No <type> Content to Display" are classified unavailable rather than failed, and the dialog reports them as skipped instead of listing them as errors.

Two smaller fixes found along the way:

- The result dialog keyed its failure list on item.classId, but a class appears once per content type, so a 528-entry list had roughly 5x duplicate React keys and the Close button stopped working. Keys now include content type and index, and the list is capped at 50 rendered entries with an overflow count.
- parallelBatch was a fixed-window batcher: it awaited every item in a window before starting the next, so one slow file left the other four slots idle. It is now a worker pool that keeps `concurrency` requests in flight. Roughly 2x faster on a mixed-duration benchmark; results stay in input order.

Im just a student at PES, I do not know how to develop extensions, I used AI to assist me to figure out what was not working and used it to write the fix as well, I did testing by hand on my own account before opening these PRs.